### PR TITLE
MELOSYS-2730: Manglende landkoder i iso2-tabellen

### DIFF
--- a/src/main/resources/kodeset.yml
+++ b/src/main/resources/kodeset.yml
@@ -246,6 +246,8 @@ landkoder:
   DE: Tyskland
   HU: Ungarn
   AT: Østerrike
+  AX: Åland
+  SJ: Svalbard og Jan Mayen
 lovvalgsbestemmelser:
   lovvalgsBestemmelser_883_2004:
     FO_883_2004_ART11_1: Fo 883/2004 Artikkel 11 nr. 1

--- a/src/main/resources/standard/pom.xml
+++ b/src/main/resources/standard/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>no.nav.melosys</groupId>
     <artifactId>melosys-internt-kodeverk</artifactId>
-    <version>1.2.17</version>
+    <version>1.2.18</version>
     <packaging>jar</packaging>
 
     <name>melosys-internt-kodeverk</name>


### PR DESCRIPTION
Lagt til manglende iso2-koder, slik at man kan konvertere iso3 til io2 uten å feil