### PR TITLE
Legg til rette for publisering på GitHub package registry

### DIFF
--- a/.circleci/settings.xml
+++ b/.circleci/settings.xml
@@ -1,23 +1,11 @@
 <settings>
-    <servers>
-        <server>
-            <id>ossrh</id>
-            <username>${env.SONATYPE_USERNAME}</username>
-            <password>${env.SONATYPE_PASSWORD}</password>
-        </server>
-    </servers>
-
-    <profiles>
-        <profile>
-            <id>ossrh</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <properties>
-                <gpg.executable>gpg</gpg.executable>
-                <gpg.keyname>${env.GPG_KEY_NAME}</gpg.keyname>
-                <gpg.passphrase>${env.GPG_PASSPHRASE}</gpg.passphrase>
-            </properties>
-        </profile>
-    </profiles>
+    <settings>
+        <servers>
+            <server>
+                <id>github</id>
+                <username>x-access-token</username>
+                <password>${GITHUB_TOKEN}</password>
+            </server>
+        </servers>
+    </settings>
 </settings>

--- a/.circleci/settings.xml
+++ b/.circleci/settings.xml
@@ -1,11 +1,9 @@
 <settings>
-    <settings>
-        <servers>
-            <server>
-                <id>github</id>
-                <username>x-access-token</username>
-                <password>${GITHUB_TOKEN}</password>
-            </server>
-        </servers>
-    </settings>
+    <servers>
+        <server>
+            <id>github</id>
+            <username>x-access-token</username>
+            <password>${GITHUB_TOKEN}</password>
+        </server>
+    </servers>
 </settings>

--- a/melosys-kodeverk-generator/src/main/resources/templates/pom.xml
+++ b/melosys-kodeverk-generator/src/main/resources/templates/pom.xml
@@ -35,13 +35,9 @@
     </scm>
 
     <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
         <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <id>github</id>
+            <url>https://maven.pkg.github.com/navikt/melosys-kodeverk</url>
         </repository>
     </distributionManagement>
 
@@ -127,25 +123,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>default-deploy</id>
-                        <phase>deploy</phase>
-                        <!-- By default, this is the phase deploy goal will bind to -->
-                        <goals>
-                            <goal>deploy</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                    <serverId>ossrh</serverId>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>versions-maven-plugin</artifactId>
             </plugin>
@@ -219,25 +196,6 @@
                                 </configuration>
                             </execution>
                         </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>sign-artifacts</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>sign</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <gpgArguments>
-                                <arg>--pinentry-mode</arg>
-                                <arg>loopback</arg>
-                            </gpgArguments>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
GitHub package registry ser ikke ut til å støtte snapshots, så jeg fjerner det her, og faker snapshots i `melosys-kodeverk` pipeline med release av artifact versjon `[VERSJON]-[SHORT_SHA]-SNAPSHOT` (om nødvendig). GPG trengs ikke mot GPR, og `nexus-staging-maven-plugin` feiler med `400 Bad Request` ved overføring av metadata. Så vidt jeg skjønner av dokumentasjonen, brukes denne til å se etter nyere snapshot-versjoner, så det er sannsynligvis derfor det feiler, og jeg tenker at det da heller ikke er nødvendig. Jeg har publisert flere artifakter på en fork av `melosys-kodeverk` som ser OK ut, og det skader ikke å bygge et nytt Docker-image med disse endringene for bruk på GitHub Actions i parallell med CircleCI, siden de bygger på en angitt tag (ikke latest).